### PR TITLE
Fix package names (alarm)

### DIFF
--- a/Storage.sh
+++ b/Storage.sh
@@ -174,31 +174,24 @@ if [[ -n "`which apt`" ]]; then
 # Next test for Pac-Man (Arch Linux)
 elif [ -n "`which pacman`" ]; then
   pacman -Syy
-  pacman --needed --noconfirm -S vim
-  pacman --needed --noconfirm -S hdparm
-  pacman --needed --noconfirm -S base-devel
-  pacman --needed --noconfirm -S fio
-  pacman --needed --noconfirm -S bc
-  pacman --needed --noconfirm -S curl
-  pacman --needed --noconfirm -S lshw
-  pacman --needed --noconfirm -S usbutils
-  pacman --needed --noconfirm -S pciutils
-  pacman --needed --noconfirm -S lsscsi
-  pacman --needed --noconfirm -S dmidecode
+  pacman --needed --noconfirm -S \
+    base-devel \
+    bc \
+    curl \
+    dmidecode \
+    fio \
+    hdparm \
+    lshw \
+    lsscsi \
+    pciutils \
+    usbutils
 
   # Install iozone
   if ! command -v iozone
   then
-    if ! command -v yay
-    then
-      mkdir /tmp/yay
-      cd /tmp/yay
-      curl -L -o PKGBUILD "https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=yay"
-      makepkg -si --noconfirm --needed
-      rm -rf /tmp/yay
-    fi
-    gpg --recv-key 8C004C2F93481F6B
-    yay -S --noconfirm iozone
+    echo "Please install iozone via the AUR for this script to work" >&2
+    echo "https://aur.archlinux.org/packages/iozone/" >&2
+    exit 3
   fi
 
   # Check if running on a Raspberry Pi

--- a/Storage.sh
+++ b/Storage.sh
@@ -181,10 +181,9 @@ elif [ -n "`which pacman`" ]; then
   pacman --needed --noconfirm -S bc
   pacman --needed --noconfirm -S curl
   pacman --needed --noconfirm -S lshw
-  pacman --needed --noconfirm -S lsusb
-  pacman --needed --noconfirm -S lspci
+  pacman --needed --noconfirm -S usbutils
+  pacman --needed --noconfirm -S pciutils
   pacman --needed --noconfirm -S lsscsi
-  pacman --needed --noconfirm -S iozone3
   pacman --needed --noconfirm -S dmidecode
 
   # Check if running on a Raspberry Pi

--- a/Storage.sh
+++ b/Storage.sh
@@ -186,6 +186,21 @@ elif [ -n "`which pacman`" ]; then
   pacman --needed --noconfirm -S lsscsi
   pacman --needed --noconfirm -S dmidecode
 
+  # Install iozone
+  if ! command -v iozone
+  then
+    if ! command -v yay
+    then
+      mkdir /tmp/yay
+      cd /tmp/yay
+      curl -L -o PKGBUILD "https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=yay"
+      makepkg -si --noconfirm --needed
+      rm -rf /tmp/yay
+    fi
+    gpg --recv-key 8C004C2F93481F6B
+    yay -S --noconfirm iozone
+  fi
+
   # Check if running on a Raspberry Pi
   if [[ $HostModel == *"Raspberry Pi"* ]]; then
     if [ ! -n "`which vcgencmd`" ]; then


### PR DESCRIPTION
On alarm, `lsusb` and `lspci` are provided respectively by `usbtuils` and `pciutils`.

```bash
sudo pacman -Qo lspci lsusb                                                                                                                                                                                                
/usr/bin/lspci is owned by pciutils 3.6.2-2
/usr/bin/lsusb is owned by usbutils 012-2
```

Also. iozone3 is not installable without the AUR. That's why I removed the `pacman -S iozone3` bit as well.

```bash
sudo pacman -S iozone3 iozone                                                                                                                                                                                         
error: target not found: iozone3
error: target not found: iozone

yay iozone                                                                                                                                                                                                            
1 aur/iozone 3.484-1 (+23 0.00%) 
    A filesystem benchmark tool
==> Packages to install (eg: 1 2 3, 1-3 or ^4)
==>
```

https://aur.archlinux.org/packages/iozone/